### PR TITLE
Changes in the intro notebook

### DIFF
--- a/mofapy2/notebooks/getting_started_python.ipynb
+++ b/mofapy2/notebooks/getting_started_python.ipynb
@@ -16,7 +16,7 @@
    "metadata": {},
    "source": [
     "This notebook contains a detailed tutorial on how to train MOFA using Python.\n",
-    "A template script to run the code below can be found [here](https://github.com/bioFAM/MOFA2/blob/master/template_script.py)"
+    "A template script to run the code below can be found [here](https://github.com/bioFAM/MOFA2/blob/master/template_script.py)."
    ]
   },
   {
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:25:16.898360Z",
@@ -81,14 +81,14 @@
     "\n",
     "For example:\n",
     "```\n",
-    "sample  group   feature value   view\n",
-    "sample1  groupA    gene1   2.8044  RNA\n",
-    "sample1  groupA    gene3    2.2069  RNA\n",
-    "sample2  groupB    gene2    0.1454  RNA\n",
-    "sample2  groupB    gene1     2.7021  RNA\n",
-    "sample2  groupB    promoter1    3.8618  Methylation\n",
-    "sample3  groupB    promoter2    3.2545  Methylation\n",
-    "sample3  groupB    promoter3   1.5014  Methylation\n",
+    "sample   group   feature    value   view\n",
+    "sample1  groupA  gene1      2.8044  RNA\n",
+    "sample1  groupA  gene3      2.2069  RNA\n",
+    "sample2  groupB  gene2      0.1454  RNA\n",
+    "sample2  groupB  gene1      2.7021  RNA\n",
+    "sample2  groupB  promoter1  3.8618  Methylation\n",
+    "sample3  groupB  promoter2  3.2545  Methylation\n",
+    "sample3  groupB  promoter3  1.5014  Methylation\n",
     "```"
    ]
   },
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:25:20.952029Z",
@@ -191,7 +191,7 @@
        "4  sample_4_group_0  group_0  feature_0_view_0  view_0  -0.88"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -224,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:25:21.324421Z",
@@ -259,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:25:21.371541Z",
@@ -281,12 +281,12 @@
     "### 2.4) Add the data to the model\n",
     "\n",
     "This has to be run after defining the data options\n",
-    "- **likelihods**: a list of strings, either \"gaussian\", \"poisson\" or \"bernoulli\". If None (default), they are guessed internally"
+    "- **likelihoods**: a list of strings, either \"gaussian\", \"poisson\" or \"bernoulli\". If None (default), they are guessed internally"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:25:21.862319Z",
@@ -338,15 +338,15 @@
     "\n",
     "- **factors**: number of factors\n",
     "- **spikeslab_weights**: use spike-slab sparsity prior in the weights? default is TRUE\n",
-    "- **ard_factors**: use ARD prior in the factors? Default is TRUE if using multiple groups. This is ugessed by default.\n",
-    "- **ard_weights**: use ARD prior in the weights? Default is TRUE if using multiple views. This is guessed by default\n",
+    "- **ard_factors**: use ARD prior in the factors? Default is TRUE if using multiple groups. This is guessed by default.\n",
+    "- **ard_weights**: use ARD prior in the weights? Default is TRUE if using multiple views. This is guessed by default.\n",
     "\n",
     "Only change the default model options if you are familiar with the underlying mathematical model!\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:25:26.955109Z",
@@ -397,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:25:29.519460Z",
@@ -437,7 +437,7 @@
    "source": [
     "##### 5) (Optional)  stochastic inference options\n",
     "\n",
-    "If the number of samples is very large (at the order of >1e4), you may want to try the stochastic inference scheme. However, it requires some additional hyperparameters that in some data sets may need to be optimised (see the [stochastic vignette](https://raw.githack.com/bioFAM/MOFA2/master/MOFA2/vignettes/stochastic_inference.html)).\n",
+    "If the number of samples is very large (in the order of >1e4), you may want to try the stochastic inference scheme. However, it requires some additional hyperparameters that in some data sets may need to be optimised (see the [stochastic vignette](https://raw.githack.com/bioFAM/MOFA2/master/MOFA2/vignettes/stochastic_inference.html)).\n",
     "\n",
     "- **batch_size**: float value indicating the batch size (as a fraction of the total data set: either 0.10, 0.25 or 0.50)\n",
     "- **learning_rate**: learning rate (we recommend values from 0.25 to 0.50)\n",
@@ -446,17 +446,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
     "# We do not want to use stochastic inference for this data set\n",
     "\n",
     "# ent.set_stochastic_options(\n",
-    "# batch_size = 0.5,\n",
-    "# learning_rate = 0.5, \n",
-    "# forgetting_rate = 0.25\n",
-    "#)"
+    "#     batch_size = 0.5,\n",
+    "#     learning_rate = 0.5, \n",
+    "#     forgetting_rate = 0.25\n",
+    "# )"
    ]
   },
   {
@@ -470,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:27:21.866240Z",
@@ -545,8 +545,8 @@
       "#######################\n",
       "\n",
       "\n",
-      "Saving model in /Users/ricard/data/mofaplus/hdf5/test.hdf5...\n",
-      "\n"
+      "No output file name provided as a training options or to the save method. Saving to /tmp/mofa_20210223-153612.hdf5 .\n",
+      "Saving model in /tmp/mofa_20210223-153612.hdf5...\n"
      ]
     }
    ],
@@ -556,8 +556,7 @@
     "ent.run()\n",
     "\n",
     "# Save the output\n",
-    "outfile = \"/Users/ricard/data/mofaplus/hdf5/test.hdf5\"\n",
-    "ent.save(outfile)"
+    "ent.save(outfile=None)"
    ]
   },
   {
@@ -566,7 +565,7 @@
    "source": [
     "## 7) Downstream analysis\n",
     "\n",
-    "This finishes the tutorial on how to train a MOFA object from python. To continue with the downstream analysis you have to switch to R. Please, follow [this tutorial](https://raw.githack.com/bioFAM/MOFA2/master/MOFA2/vignettes/downstream_analysis.html)"
+    "This finishes the tutorial on how to train a MOFA object from python. To continue with the downstream analysis you have to switch to R. Please, follow [this tutorial](https://raw.githack.com/bioFAM/MOFA2/master/MOFA2/vignettes/downstream_analysis.html)."
    ]
   }
  ],
@@ -586,7 +585,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.8.8"
   },
   "latex_metadata": {
    "affiliation": "European Bioinformatics Institute, Cambridge, UK",
@@ -633,5 +632,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/mofapy2/notebooks/getting_started_python.ipynb
+++ b/mofapy2/notebooks/getting_started_python.ipynb
@@ -16,7 +16,7 @@
    "metadata": {},
    "source": [
     "This notebook contains a detailed tutorial on how to train MOFA using Python.\n",
-    "A template script to run the code below can be found [here](https://github.com/bioFAM/MOFA2/blob/master/template_script.py)."
+    "A template script to run the code below can be found [here](https://github.com/bioFAM/MOFA2/blob/master/inst/scripts/template_script.py)."
    ]
   },
   {

--- a/mofapy2/notebooks/getting_started_python.ipynb
+++ b/mofapy2/notebooks/getting_started_python.ipynb
@@ -191,7 +191,7 @@
        "4  sample_4_group_0  group_0  feature_0_view_0  view_0  -0.88"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -224,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:25:21.324421Z",
@@ -259,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:25:21.371541Z",
@@ -286,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:25:21.862319Z",
@@ -346,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:25:26.955109Z",
@@ -397,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:25:29.519460Z",
@@ -446,7 +446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -470,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-06T20:27:21.866240Z",
@@ -585,7 +585,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.6.7"
   },
   "latex_metadata": {
    "affiliation": "European Bioinformatics Institute, Cambridge, UK",
@@ -632,5 +632,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
This PR fixes some minor things I came across when running the tutorial notebook:
- fixes some typos
- resets the cells'  `execution_count`s to their natural ordering
- sets `ent.save(outfile=None)` instead of specifying a hardcoded `outfile`, which raised an error previously

Hope this helps. Feel free to reroute this to the _dev_ branch, but as this is not a (breaking) code change the _master_ branch should be okay.