### PR TITLE
Remove toml dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ homepage = "https:/biofam.github.io/MOFA2/"
 
 [tool.poetry.dependencies]
 python = "^3.6.1"
-toml = "^0.9"
 numpy = "^1.17.0"
 pandas = "^1.0.0"
 scipy = "^1.3.0"


### PR DESCRIPTION
Hello!

Thanks for the excellent work with mofapy2. We are trying to install mofapy2 alongside our other dependencies - and we are having conflicts due to `toml` being pinned to a strict version in `mofapy2`. I was wondering if it was possible to remove the `toml` dependency as I do not see any use of the `toml` package inside the python package?

And if it would be possible to cut a new release with this change it would be much appreciated :)