### PR TITLE
Fix: Replace deprecated `np.Inf` with `np.inf`

### DIFF
--- a/mofapy2/core/nodes/Sigma_node.py
+++ b/mofapy2/core/nodes/Sigma_node.py
@@ -624,7 +624,7 @@ class Sigma_Node_base(Node):
         # optimise hyperparamters of GP
         for k in range(K):
             best_zeta = -1
-            best_elbo = -np.Inf
+            best_elbo = -np.inf
 
             # set initial values for optimization
             if self.model_groups:
@@ -1193,7 +1193,7 @@ class Sigma_Node_warping(Sigma_Node_base):
 #
 #                 best_i = -1
 #                 best_zeta = -1
-#                 best_elbo = -np.Inf
+#                 best_elbo = -np.inf
 #
 #                 # set initial values for optimization
 #                 ZE = copy.deepcopy(var.getExpectation())


### PR DESCRIPTION
Replaced `np.Inf` with `np.inf` for compatibility with newer versions of NumPy, as `np.Inf` raises an AttributeError.